### PR TITLE
Update benchmarking.md

### DIFF
--- a/docs/concepts/benchmarking.md
+++ b/docs/concepts/benchmarking.md
@@ -11,9 +11,9 @@ Collections of tasks can be published as _benchmarking suites_. Seamlessly integ
 
 You can search for <a href="https://www.openml.org/search?type=benchmark&sort=tasks_included&study_type=task" target="_blank">all existing benchmarking suites</a> or create your own. For all further details, see the [benchmarking guide](../benchmark/index.md).
 
-<img src="../img/studies.png" style="width:100%; max-width:800px;"/>
+<img src="../../img/studies.png" style="width:100%; max-width:800px;"/>
 
 ## Benchmark studies
 Collections of runs can be published as _benchmarking studies_. They contain the results of all runs (possibly millions) executed on a specific benchmarking suite. OpenML allows you to easily download all such results at once via the APIs, but also visualized them online in the Analysis tab (next to the complete list of included tasks and runs). Below is an example of <a href="https://www.openml.org/search?type=benchmark&study_type=run&id=226" target="_blamnk">a benchmark study for AutoML algorithms</a>.
 
-<img src="../img/run_study.png" style="width:100%; max-width:1000px;"/>
+<img src="../../img/run_study.png" style="width:100%; max-width:1000px;"/>


### PR DESCRIPTION
### Summary
This PR fixes incorrect image paths and updates a link to the correct benchmarking guide.

### Changes
- Updated 2 image paths to ensure correct rendering
- Updated link from `benchmark/benchmark.md` to `benchmark/index.md`

### Reason
The previous paths caused broken images and the link pointed to a non-existing page.
