### PR TITLE
Fix: Correct Code Reference path in Python nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -199,7 +199,7 @@ nav:
     - Questions: help/index.md
     - Python:
         - python/index.md
-        - Code Reference: reference/
+        - Code Reference: python/reference/
         - Examples: examples/
         - Usage: python/usage.md
         - Contributing: python/contributing.md


### PR DESCRIPTION
Closes #43 
Changed `reference/` to `python/reference/` so the Code Reference link points to `/python/reference/` instead of `/reference/`